### PR TITLE
Update _config.yml to pin Jekyll theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,7 +97,7 @@ plugins:
 paginate: 10
 paginate_path: /page:num/
 
-remote_theme: jekyll/minima
+remote_theme: jekyll/minima@41b97699af658128fa9983e5312ca5516641f335
 
 titles_from_headings:
   enabled:     true


### PR DESCRIPTION
Pins Jekyll theme to keep site-building see https://stackoverflow.com/questions/74408145/minima-theme-build-shows-liquid-exception-invalid-syntax-for-include-tag-file. 