### PR TITLE
Refresh About page intro

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -20,7 +20,9 @@ about:
 
 Hi, I’m Daniel van Strien, a Machine Learning Librarian at [Hugging Face](https://huggingface.co/).
 
-I started out in libraries and digital humanities, including time at the British Library on the [Living with Machines](https://livingwithmachines.ac.uk/) project. I’ve also worked in academic libraries supporting open access and open science.
+Most of my work splits between two threads: making the Hugging Face Hub a better place to work with data, and helping libraries, archives, and museums use AI on their actual collections.
+
+I started my career in libraries and digital humanities, including work at the British Library on the [Living with Machines](https://livingwithmachines.ac.uk/) project, and spent time supporting open access in academic libraries before moving into AI as the world’s first Machine Learning Librarian.
 
 My work lives at the intersection of open-source technology, information management, and applied AI. Whether I’m building tools, writing tutorials, or contributing to community projects, I’m focused on making complex systems more usable, transparent, and inclusive.
 


### PR DESCRIPTION
Update the opening paragraphs to reflect current work split between Hub data tooling and AI for libraries/archives/museums, and add the world's first Machine Learning Librarian framing.