### PR TITLE
Add agent-race post: comparing two agents on biglam/on_the_books

### DIFF
--- a/posts/2026/agent-race/claude-workspace/train_jim_crow.py
+++ b/posts/2026/agent-race/claude-workspace/train_jim_crow.py
@@ -1,0 +1,201 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "datasets>=3.0",
+#     "transformers>=4.48",
+#     "torch>=2.4",
+#     "accelerate>=1.0",
+#     "scikit-learn>=1.5",
+#     "huggingface-hub>=0.27",
+# ]
+# ///
+"""Fine-tune ModernBERT-base on biglam/on_the_books for Jim Crow law detection.
+
+Binary classification on `section_text` -> `jim_crow` (0=no_jim_crow, 1=jim_crow).
+Stratified 80/20 train/eval split. Class-weighted cross-entropy to handle the
+~29% positive imbalance. Pushes the trained model to the Hub.
+"""
+
+from __future__ import annotations
+
+
+import numpy as np
+import torch
+import torch.nn as nn
+from datasets import load_dataset
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    precision_recall_fscore_support,
+    roc_auc_score,
+)
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    DataCollatorWithPadding,
+    Trainer,
+    TrainingArguments,
+)
+
+MODEL_ID = "answerdotai/ModernBERT-base"
+DATASET_ID = "biglam/on_the_books"
+PUSH_TO = "davanstrien/jim-crow-laws-claude-code"
+MAX_LENGTH = 1024  # covers ~95th pct of section_text; truncates long-tail
+SEED = 42
+
+
+def main() -> None:
+    print(f"Loading dataset {DATASET_ID}")
+    raw = load_dataset(DATASET_ID, split="train")
+    print(f"Total rows: {len(raw)}")
+
+    # Stratified 80/20 split on the label
+    split = raw.train_test_split(
+        test_size=0.2, seed=SEED, stratify_by_column="jim_crow"
+    )
+    train_ds, eval_ds = split["train"], split["test"]
+    print(f"Train: {len(train_ds)}  Eval: {len(eval_ds)}")
+    print(
+        "Train label dist:",
+        dict(zip(*np.unique(train_ds["jim_crow"], return_counts=True))),
+    )
+    print(
+        "Eval label dist :",
+        dict(zip(*np.unique(eval_ds["jim_crow"], return_counts=True))),
+    )
+
+    # Class weights from the training split (inverse frequency)
+    train_labels = np.array(train_ds["jim_crow"])
+    counts = np.bincount(train_labels, minlength=2)
+    n_total = counts.sum()
+    class_weights = torch.tensor(
+        n_total / (2.0 * counts), dtype=torch.float
+    )
+    print(f"Class weights: {class_weights.tolist()}")
+
+    print(f"Loading tokenizer + model {MODEL_ID}")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    label_names = raw.features["jim_crow"].names  # ["no_jim_crow", "jim_crow"]
+    id2label = {i: n for i, n in enumerate(label_names)}
+    label2id = {n: i for i, n in enumerate(label_names)}
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        MODEL_ID,
+        num_labels=2,
+        id2label=id2label,
+        label2id=label2id,
+    )
+
+    def tokenize(batch):
+        return tokenizer(
+            batch["section_text"],
+            truncation=True,
+            max_length=MAX_LENGTH,
+        )
+
+    keep_cols = ["jim_crow"]
+    train_tok = train_ds.map(
+        tokenize,
+        batched=True,
+        remove_columns=[c for c in train_ds.column_names if c not in keep_cols],
+    ).rename_column("jim_crow", "labels")
+    eval_tok = eval_ds.map(
+        tokenize,
+        batched=True,
+        remove_columns=[c for c in eval_ds.column_names if c not in keep_cols],
+    ).rename_column("jim_crow", "labels")
+
+    data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
+
+    def compute_metrics(eval_pred):
+        logits, labels = eval_pred
+        preds = np.argmax(logits, axis=-1)
+        probs = torch.softmax(torch.tensor(logits), dim=-1).numpy()[:, 1]
+        prec, rec, f1, _ = precision_recall_fscore_support(
+            labels, preds, average="binary", pos_label=1, zero_division=0
+        )
+        return {
+            "accuracy": accuracy_score(labels, preds),
+            "precision_jim_crow": prec,
+            "recall_jim_crow": rec,
+            "f1_jim_crow": f1,
+            "f1_macro": f1_score(labels, preds, average="macro", zero_division=0),
+            "roc_auc": roc_auc_score(labels, probs),
+        }
+
+    output_dir = "./jim-crow-output"
+
+    args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=5,
+        per_device_train_batch_size=16,
+        per_device_eval_batch_size=32,
+        learning_rate=3e-5,
+        weight_decay=0.01,
+        warmup_ratio=0.1,
+        lr_scheduler_type="linear",
+        eval_strategy="epoch",
+        save_strategy="epoch",
+        save_total_limit=1,
+        load_best_model_at_end=True,
+        metric_for_best_model="f1_jim_crow",
+        greater_is_better=True,
+        logging_steps=20,
+        report_to="none",
+        bf16=torch.cuda.is_available(),
+        seed=SEED,
+        push_to_hub=True,
+        hub_model_id=PUSH_TO,
+        hub_strategy="end",
+        hub_private_repo=False,
+    )
+
+    class WeightedTrainer(Trainer):
+        def __init__(self, *a, class_weights=None, **kw):
+            super().__init__(*a, **kw)
+            self._cw = class_weights
+
+        def compute_loss(
+            self, model, inputs, return_outputs=False, num_items_in_batch=None
+        ):
+            labels = inputs.pop("labels")
+            outputs = model(**inputs)
+            logits = outputs.logits
+            loss_fct = nn.CrossEntropyLoss(
+                weight=self._cw.to(logits.device) if self._cw is not None else None
+            )
+            loss = loss_fct(logits, labels)
+            return (loss, outputs) if return_outputs else loss
+
+    trainer = WeightedTrainer(
+        model=model,
+        args=args,
+        train_dataset=train_tok,
+        eval_dataset=eval_tok,
+        processing_class=tokenizer,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics,
+        class_weights=class_weights,
+    )
+
+    print("Starting training")
+    trainer.train()
+
+    print("Final eval on held-out split:")
+    final = trainer.evaluate()
+    for k, v in final.items():
+        print(f"  {k}: {v}")
+
+    print(f"Pushing model to {PUSH_TO}")
+    trainer.push_to_hub(
+        commit_message="Fine-tuned ModernBERT-base on biglam/on_the_books"
+    )
+
+    # Also push tokenizer explicitly to be safe
+    tokenizer.push_to_hub(PUSH_TO)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/posts/2026/agent-race/index.qmd
+++ b/posts/2026/agent-race/index.qmd
@@ -17,7 +17,18 @@ I gave two coding agents the same one-line task and watched what each one decide
 
 The task: fine-tune a model on [`biglam/on_the_books`](https://huggingface.co/datasets/biglam/on_the_books) — UNC Chapel Hill Libraries' labelled training set from *On the Books: Jim Crow and Algorithms of Resistance* — and push the trained classifier to the Hub. Train via [`hf jobs`](https://huggingface.co/docs/huggingface_hub/guides/cli#hf-jobs).
 
-One agent was [Pi](https://pi.dev/) running on Kimi K2.6 (open weights, via API). The other was Claude Code on Opus 4.7. Same prompt, parallel runs, ~13 minutes each.
+::: {.callout-tip collapse="true"}
+## Preview the dataset
+
+<iframe
+  src="https://huggingface.co/datasets/biglam/on_the_books/embed/viewer/default/train"
+  frameborder="0"
+  width="100%"
+  height="560px"
+></iframe>
+:::
+
+One agent was [Pi](https://pi.dev/) running on [Kimi K2.6](https://huggingface.co/moonshotai/Kimi-K2.6) (open weights, via API). The other was Claude Code on Opus 4.7. Same prompt, parallel runs, ~13 minutes each.
 
 ## The prompt
 
@@ -61,8 +72,8 @@ Both produced working binary classifiers. The headline numbers are close:
 | Model card | full (use, limits, ethics, hparams, citation) | auto-generated `Trainer` placeholder |
 | Domain tags | 7 | 0 |
 
-→ Claude's model: [`davanstrien/jim-crow-laws-claude-code`](https://huggingface.co/davanstrien/jim-crow-laws-claude-code)
-→ Pi+Kimi's model: [`davanstrien/jim-crow-laws-pi-kimi`](https://huggingface.co/davanstrien/jim-crow-laws-pi-kimi)
+- Claude's model: [`davanstrien/jim-crow-laws-claude-code`](https://huggingface.co/davanstrien/jim-crow-laws-claude-code)
+- Pi+Kimi's model: [`davanstrien/jim-crow-laws-pi-kimi`](https://huggingface.co/davanstrien/jim-crow-laws-pi-kimi)
 
 ## The interesting bit
 

--- a/posts/2026/agent-race/index.qmd
+++ b/posts/2026/agent-race/index.qmd
@@ -1,0 +1,117 @@
+---
+title: "Two agents, one prompt"
+subtitle: "Pi + Kimi K2.6 and Claude Code both fine-tuned a Jim Crow law classifier from a single sentence. The interesting gap wasn't F1."
+date: "2026-05-01"
+author: "Daniel van Strien"
+categories: [coding-agents, hugging-face, glam, datasets]
+description: "I gave two coding agents the same one-line prompt and watched what each decided to do. Both shipped working classifiers via hf jobs. The headline metrics were within 1.5pp — the interesting differences were everywhere else."
+image: ""
+format:
+  html:
+    toc: false
+---
+
+Agents are getting more and more capable of training models. This means domain experts can have agents fine tune models for them without needing to write code themselves. But how do different agents approach the same task? Do they make the same choices? How good are the models they produce? 
+
+I gave two coding agents the same one-line task and watched what each one decided to do.
+
+The task: fine-tune a model on [`biglam/on_the_books`](https://huggingface.co/datasets/biglam/on_the_books) — UNC Chapel Hill Libraries' labelled training set from *On the Books: Jim Crow and Algorithms of Resistance* — and push the trained classifier to the Hub. Train via [`hf jobs`](https://huggingface.co/docs/huggingface_hub/guides/cli#hf-jobs).
+
+One agent was [Pi](https://pi.dev/) running on Kimi K2.6 (open weights, via API). The other was Claude Code on Opus 4.7. Same prompt, parallel runs, ~13 minutes each.
+
+## The prompt
+
+```
+Fine-tune a model on biglam/on_the_books to identify Jim Crow laws.
+Train via hf jobs and push the trained model to my namespace.
+
+Run `hf --help` to understand the Hub CLI and `hf jobs uv run --help`
+to understand how to submit uv scripts. You can use `uv run --with`
+to run small scripts for exploring the dataset.
+
+Start by exploring the dataset structure, then proceed to choose
+and fine-tune an appropriate model.
+
+Push the final model to davanstrien/<repo-name>.
+```
+
+## The race
+
+<video controls width="100%" preload="metadata">
+  <source src="https://huggingface.co/buckets/davanstrien/blog-assets/resolve/agent-race.mp4?download=true" type="video/mp4">
+  Your browser doesn't support embedded video. <a href="https://huggingface.co/buckets/davanstrien/blog-assets/resolve/agent-race.mp4?download=true">Download the recording</a>.
+</video>
+
+::: {.callout-note}
+The two terminals are running side-by-side: Claude Code on the left, Pi+Kimi on the right. Both call `hf` directly, both submit `hf jobs uv run`, both push to the Hub when training finishes.
+:::
+
+## What each one shipped
+
+Both produced working binary classifiers. The headline numbers are close:
+
+| | **Claude Code (Opus 4.7)** | **Pi + Kimi K2.6** |
+|---|---|---|
+| Base model | **ModernBERT-base** (8K context) | RoBERTa-base |
+| Wall-clock | ~13 min | ~13 min |
+| F1 (jim_crow) | 0.962 | 0.947 |
+| Accuracy | 0.978 | (not reported) |
+| Hardware | L4 via `hf jobs` | L4 via `hf jobs` |
+| Class imbalance handling | inverse-frequency weighted loss | not addressed |
+| Model card | full (use, limits, ethics, hparams, citation) | auto-generated `Trainer` placeholder |
+| Domain tags | 7 | 0 |
+
+→ Claude's model: [`davanstrien/jim-crow-laws-claude-code`](https://huggingface.co/davanstrien/jim-crow-laws-claude-code)
+→ Pi+Kimi's model: [`davanstrien/jim-crow-laws-pi-kimi`](https://huggingface.co/davanstrien/jim-crow-laws-pi-kimi)
+
+## The interesting bit
+
+The F1 gap is real but small. What's more striking is what each agent *decided* to do beyond producing weights:
+
+- **Base model choice.** Claude Code picked ModernBERT — the obvious 2025 choice for legal text given its 8K context window. Pi+Kimi went with RoBERTa-base. Both produce viable classifiers; only one of those is a current decision.
+- **The label-leak gotcha.** The dataset's `source` field is 100% positive for `paschal` and 92% positive for `murray` — using it as a feature would leak the label. Claude noticed this in the dataset card and explicitly excluded `source`. Pi+Kimi didn't mention it.
+- **Class imbalance.** ~29% of the data is positive. Claude added inverse-frequency class weights to the loss; Pi+Kimi trained with default cross-entropy.
+- **The model card.** Claude wrote a full card with intended use, limitations, OCR-noise caveats, ethical framing carried over from the dataset, full hyperparameters, per-epoch metrics, and a citation back to the *On the Books* project. Pi+Kimi shipped the auto-generated `Trainer` template with three "More information needed" placeholders.
+- **Discoverability.** Claude added seven domain tags (`legal`, `glam`, `jim-crow`, `north-carolina`, `history`, etc.). Pi+Kimi added zero. One of these models is findable by an archivist; the other isn't.
+
+## What this means
+
+Agents are able to produce working models with minimal prompting and no code. Using [Hugging Face Jobs](https://huggingface.co/docs/huggingface_hub/guides/cli#hf-jobs) means you don't need local GPU access or ML expertise to get a model trained and pushed to the Hub. One of the reasons in the past people didn't bother training task and domain-specific models was the friction of setting up training pipelines; agents + hf jobs are changing that.
+
+IMO the biggest gap is still datasets (sorry broken record). In my experience agents still struggle when working with domain specific data "from scratch" but likely with some hand holding from a domain expert the process from unlablled data -> labelled dataset -> trained model can be done with agents by a domain expert who is not an ML engineer.
+
+## Browse the agent traces
+
+Both agents' full session traces are on the Hub using the new [agent trace viewer](https://huggingface.co/changelog/agent-trace-viewer). You can step through each turn, tool call, and model response:
+
+<iframe
+  src="https://huggingface.co/datasets/davanstrien/agent-race-traces/embed/viewer/default/train"
+  frameborder="0"
+  width="100%"
+  height="560px"
+></iframe>
+
+Direct links to each session file:
+
+- Claude Code: [`claude-code.jsonl`](https://huggingface.co/datasets/davanstrien/agent-race-traces/blob/main/claude-code.jsonl)
+- Pi + Kimi: [`pi-kimi.jsonl`](https://huggingface.co/datasets/davanstrien/agent-race-traces/blob/main/pi-kimi.jsonl)
+
+## Reproduce / inspect
+
+- Dataset: [`biglam/on_the_books`](https://huggingface.co/datasets/biglam/on_the_books)
+- Claude Code's training script: [`claude-workspace/train_jim_crow.py`](claude-workspace/train_jim_crow.py)
+- Pi+Kimi's training script: [`pi-workspace/train.py`](pi-workspace/train.py)
+- Claude's model: [`davanstrien/jim-crow-laws-claude-code`](https://huggingface.co/davanstrien/jim-crow-laws-claude-code)
+- Pi+Kimi's model: [`davanstrien/jim-crow-laws-pi-kimi`](https://huggingface.co/davanstrien/jim-crow-laws-pi-kimi)
+- Agent traces: [`davanstrien/agent-race-traces`](https://huggingface.co/datasets/davanstrien/agent-race-traces)
+
+## Try it yourself
+
+- **[HF Jobs](https://huggingface.co/docs/huggingface_hub/guides/cli#hf-jobs)** — launch GPU training from the CLI without managing infrastructure
+- **[Agent trace viewer](https://huggingface.co/changelog/agent-trace-viewer)** — host and browse coding-agent sessions on the Hub
+
+## Caveats
+
+N=1, single dataset, single prompt, single run per agent. Run-to-run variance from random seeds and agent non-determinism would shift the numbers within a few points either way. Don't read this as a benchmark — read it as a snapshot of what each agent *chose to do* given the same minimal brief. A fairer comparison would repeat both runs across multiple datasets and seeds, and would also try frontier-open (e.g. Claude Code on Kimi K2.6) and open-frontier (Pi on Opus 4.7) crosses to disentangle agent-vs-model effects.
+
+Credit to the *[On the Books](https://onthebooks.lib.unc.edu/)* project at UNC Chapel Hill Libraries for the underlying data and the *algorithms of resistance* framing.

--- a/posts/2026/agent-race/pi-workspace/train.py
+++ b/posts/2026/agent-race/pi-workspace/train.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env uv run --with transformers,datasets,accelerate,scikit-learn,evaluate,huggingface_hub
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "transformers",
+#   "datasets",
+#   "accelerate",
+#   "scikit-learn",
+#   "evaluate",
+#   "huggingface_hub",
+#   "torch",
+# ]
+# ///
+
+import os
+import evaluate
+import numpy as np
+from datasets import load_dataset
+from sklearn.model_selection import train_test_split
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    TrainingArguments,
+    Trainer,
+    DataCollatorWithPadding,
+    EarlyStoppingCallback,
+)
+
+MODEL_ID = "roberta-base"
+DATASET_ID = "biglam/on_the_books"
+OUTPUT_REPO = "davanstrien/jim-crow-laws-pi-kimi"
+TEXT_COLUMN = "section_text"
+LABEL_COLUMN = "jim_crow"
+
+# Load dataset
+ds = load_dataset(DATASET_ID, split="train")
+
+# Stratified split
+train_idx, val_idx = train_test_split(
+    range(len(ds)),
+    test_size=0.2,
+    stratify=[ex[LABEL_COLUMN] for ex in ds],
+    random_state=42,
+)
+train_ds = ds.select(train_idx)
+val_ds = ds.select(val_idx)
+
+# Tokenizer
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+def preprocess(examples):
+    return tokenizer(
+        examples[TEXT_COLUMN],
+        truncation=True,
+        max_length=512,
+    )
+
+train_ds = train_ds.map(preprocess, batched=True)
+val_ds = val_ds.map(preprocess, batched=True)
+
+# Rename label column for Trainer
+train_ds = train_ds.rename_column(LABEL_COLUMN, "labels")
+val_ds = val_ds.rename_column(LABEL_COLUMN, "labels")
+
+# Model
+model = AutoModelForSequenceClassification.from_pretrained(
+    MODEL_ID,
+    num_labels=2,
+    id2label={0: "no_jim_crow", 1: "jim_crow"},
+    label2id={"no_jim_crow": 0, "jim_crow": 1},
+)
+
+# Metrics
+metric = evaluate.load("f1")
+
+def compute_metrics(eval_pred):
+    logits, labels = eval_pred
+    preds = np.argmax(logits, axis=-1)
+    return metric.compute(predictions=preds, references=labels, average="binary")
+
+# Training args
+training_args = TrainingArguments(
+    output_dir="./results",
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    learning_rate=2e-5,
+    per_device_train_batch_size=16,
+    per_device_eval_batch_size=32,
+    num_train_epochs=5,
+    weight_decay=0.01,
+    load_best_model_at_end=True,
+    metric_for_best_model="f1",
+    greater_is_better=True,
+    push_to_hub=True,
+    hub_model_id=OUTPUT_REPO,
+    report_to="none",
+    seed=42,
+)
+
+# Trainer
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=train_ds,
+    eval_dataset=val_ds,
+    processing_class=tokenizer,
+    data_collator=DataCollatorWithPadding(tokenizer),
+    compute_metrics=compute_metrics,
+    callbacks=[EarlyStoppingCallback(early_stopping_patience=2)],
+)
+
+trainer.train()
+
+# Push final model + tokenizer
+trainer.push_to_hub()
+print(f"Model pushed to {OUTPUT_REPO}")


### PR DESCRIPTION
## Summary

Comparing Claude Code (Opus 4.7) and Pi + Kimi K2.6 on a single-sentence agent prompt: fine-tune a classifier on `biglam/on_the_books` (UNC *On the Books* Jim Crow laws dataset) and push to the Hub via `hf jobs`. Both shipped working models in ~13 min; the interesting differences were qualitative — model-card quality, base-model choice, label-leak handling.

Embeds: screen recording (HF buckets), agent-trace-viewer iframe.
Links: both trained models, training scripts, traces dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)