### PR TITLE
Publish nuextract index-cards post (draft → false)

### DIFF
--- a/posts/2026/nuextract-index-cards/index.md
+++ b/posts/2026/nuextract-index-cards/index.md
@@ -17,7 +17,7 @@ categories:
     jobs,
   ]
 image: card-to-json.png
-draft: true
+draft: false
 execute:
   eval: false
 format:


### PR DESCRIPTION
Flips `draft: false` so the post goes live (full content, listed, in the feed). Merged in #95 as a draft; Daniel is happy for it to be public now and will hold social promotion until NuMind feedback.

Rebuilt cleanly on top of the squash-merged `main` (supersedes #96, which showed the whole post folder because its base commit wasn't an ancestor of `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)