### PR TITLE
Normalise `huggingface` category tag across published posts

### DIFF
--- a/posts/2026/agent-race-traces/index.qmd
+++ b/posts/2026/agent-race-traces/index.qmd
@@ -3,7 +3,7 @@ title: "All four agents tied at F1 ~0.95. The number was a mirage."
 subtitle: "Three harnesses, two driver models, four runs. The traces show why an outcome metric on this dataset doesn't mean what the agents reported it means — and a 22-point F1 gap when you actually test for generalisation."
 date: "2026-05-06"
 author: "Daniel van Strien"
-categories: [coding-agents, hugging-face, agent-traces, glam, datasets]
+categories: [coding-agents, huggingface, agent-traces, glam, datasets]
 description: "Same one-line prompt, three harnesses, two driver models. The headline F1 tied within 1.5pp. A source-stratified eval the agents didn't run shows the headline number was hiding a 22 F1-point generalisation gap."
 image: judgment-matrix.png
 execute:

--- a/posts/2026/agent-sentiment/index.qmd
+++ b/posts/2026/agent-sentiment/index.qmd
@@ -9,7 +9,7 @@ author:
   - name: "Claude Opus 4.7"
     url: https://www.anthropic.com/claude
     affiliation: "Anthropic"
-categories: [ai, coding-agents, agent-traces, open-data, hugging-face]
+categories: [ai, coding-agents, agent-traces, open-data, huggingface]
 description: "Anthropic, OpenAI, Cursor, and Windsurf sit on millions of private agent traces. The first public corpus has 33 datasets, 1,589 sessions, 8,949 labelled messages. Here's what we found in it — and why the interesting data isn't in the words."
 execute:
   freeze: true

--- a/posts/2026/buckets-data-backend/index.qmd
+++ b/posts/2026/buckets-data-backend/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Filtering 1 TB of FineWeb-Edu for $2.40 using Buckets and Jobs"
 date: "2026-06-02"
-categories: [hugging-face, data-engineering, polars, duckdb, jobs]
+categories: [huggingface, data-engineering, polars, duckdb, jobs]
 description: "A quick look at using Hugging Face Jobs + Storage Buckets to filter a big dataset — DuckDB does the heavy scan, Polars picks up the result, a bucket is the handoff. ~1 TB filtered for about $2.40."
 image: "pipeline.png"
 draft: false

--- a/posts/2026/re-ocr-collections/index.qmd
+++ b/posts/2026/re-ocr-collections/index.qmd
@@ -2,7 +2,7 @@
 title: "Re-OCR Your Digitised Collections for ~$0.002/Page"
 date: "2026-02-19"
 author: "Daniel van Strien"
-categories: [ocr, glam, hugging-face, uv-scripts]
+categories: [ocr, glam, huggingface, uv-scripts]
 description: "A guide to re-processing digitised collections with open-source VLM-based OCR models."
 draft: false
 ---

--- a/posts/2026/structured-records-from-cards/index.qmd
+++ b/posts/2026/structured-records-from-cards/index.qmd
@@ -3,7 +3,7 @@ title: "How to turn catalogue card images into structured JSON with a 4B open mo
 subtitle: "A 4B open model turns catalogue-card images into schema-shaped JSON — the kind of structured data that can be ingested back into a library system."
 date: "2026-05-21"
 author: "Daniel van Strien"
-categories: [ocr, glam, hugging-face, structured-extraction, datasets]
+categories: [ocr, glam, huggingface, structured-extraction, datasets]
 description: "Re-OCR made digitised catalogue cards searchable as text. But libraries need structured records they can ingest into their catalogues. NuExtract3 (4B, Apache-2.0) extracts schema-shaped JSON from card images in one command — here's how it does, honestly."
 image: nls-card-to-json.png
 format:

--- a/posts/plain-text/2023-11-27-model-card.md
+++ b/posts/plain-text/2023-11-27-model-card.md
@@ -1,6 +1,6 @@
 ---
 description: "What do people talk about in their model cards?"
-categories: [Hugging Face]
+categories: [huggingface]
 title: "Extracting Insights from Model Cards Using Open Large Language Models"
 date: "2023-11-27"
 ---


### PR DESCRIPTION
Consolidates the fragmented Hugging Face category tag to a single canonical form `huggingface`.

**Scope:** 6 published posts, **category block only** — body prose "Hugging Face" is untouched.
- `hugging-face` → `huggingface`: agent-race-traces, agent-sentiment, structured-records-from-cards, buckets-data-backend, re-ocr-collections
- `Hugging Face` → `huggingface`: plain-text/2023-11-27-model-card

**Skipped:** drafts (`bpl-card-catalog`, agent-sentiment v1 backup, nuextract) and untracked/local-only posts (`agent-behavior`, `plain-text/index.qmd`, `agent-race/index.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)